### PR TITLE
Update setup.py, exclude tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author="Anton Malko",
     author_email="antonmalko@mail.ru",
     description="Client for interaction of the LOOKin device with the Home Assistant",
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests*']),
     install_requires=["aiohttp>=3.7.4"],
     classifiers=[
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
it would otherwise try to install a package called 'tests' at top level:

```
>>> Verifying ebuild manifests
>>> Emerging (1 of 1) dev-python/aiolookin-0.0.3::HomeAssistantRepository
>>> Failed to emerge dev-python/aiolookin-0.0.3, Log file:
>>>  '/var/tmp/portage/dev-python/aiolookin-0.0.3/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.18, 0.23, 0.81
 * Package:    dev-python/aiolookin-0.0.3
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   antonmalko@mail.ru
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking aiolookin-0.0.3.tar.gz to /var/tmp/portage/dev-python/aiolookin-0.0.3/work
>>> Source unpacked in /var/tmp/portage/dev-python/aiolookin-0.0.3/work
>>> Preparing source in /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
running build
running build_py
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests
copying tests/conftest.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin
copying aiolookin/models.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin
copying aiolookin/const.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin
copying aiolookin/__init__.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin
copying aiolookin/protocol.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin
copying aiolookin/error.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/http_protocol
copying tests/http_protocol/test_http_protocol.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/http_protocol
copying tests/http_protocol/__init__.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/http_protocol
copying tests/http_protocol/fixtures.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/http_protocol
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/aiolookin-0.0.3

>>> Install dev-python/aiolookin-0.0.3 into /var/tmp/portage/dev-python/aiolookin-0.0.3/image
 * python3_9: running distutils-r1_run_phase distutils-r1_python_install
python3.9 setup.py install --skip-build --root=/var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9
running install
running install_lib
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/http_protocol
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/http_protocol/test_http_protocol.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/http_protocol
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/http_protocol/__init__.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/http_protocol
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/http_protocol/fixtures.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/http_protocol
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/__init__.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/tests/conftest.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests
creating /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin/models.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin/const.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin/__init__.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin/protocol.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin
copying /var/tmp/portage/dev-python/aiolookin-0.0.3/work/aiolookin-0.0.3-python3_9/lib/aiolookin/error.py -> /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/http_protocol/test_http_protocol.py to test_http_protocol.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/http_protocol/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/http_protocol/fixtures.py to fixtures.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/tests/conftest.py to conftest.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin/models.py to models.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin/const.py to const.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin/__init__.py to __init__.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin/protocol.py to protocol.cpython-39.pyc
byte-compiling /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin/error.py to error.cpython-39.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/aiolookin-0.0.3/temp/tmp6t1sqgsb.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/aiolookin-0.0.3/temp/tmp6t1sqgsb.py
removing /var/tmp/portage/dev-python/aiolookin-0.0.3/temp/tmp6t1sqgsb.py
writing byte-compilation script '/var/tmp/portage/dev-python/aiolookin-0.0.3/temp/tmp7t8kqqok.py'
/usr/bin/python3.9 /var/tmp/portage/dev-python/aiolookin-0.0.3/temp/tmp7t8kqqok.py
removing /var/tmp/portage/dev-python/aiolookin-0.0.3/temp/tmp7t8kqqok.py
running install_egg_info
running egg_info
writing aiolookin.egg-info/PKG-INFO
writing dependency_links to aiolookin.egg-info/dependency_links.txt
writing requirements to aiolookin.egg-info/requires.txt
writing top-level names to aiolookin.egg-info/top_level.txt
listing git files failed - pretending there aren't any
reading manifest file 'aiolookin.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'aiolookin.egg-info/SOURCES.txt'
Copying aiolookin.egg-info to /var/tmp/portage/dev-python/aiolookin-0.0.3/image/_python3.9/usr/lib/python3.9/site-packages/aiolookin-0.0.3-py3.9.egg-info
running install_scripts
 * ERROR: dev-python/aiolookin-0.0.3::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2809:  Called distutils-r1_src_install
 *   environment, line 1163:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  453:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2479:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2009:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2007:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  745:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1131:  Called distutils-r1_python_install
 *   environment, line 1033:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
 * If you need support, post the output of `emerge --info '=dev-python/aiolookin-0.0.3::HomeAssistantRepository'`,
```